### PR TITLE
Rough implementation of random tokens to identify transfers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ Done.""",
             'zeroconf',
             'netifaces',
             'progressbar2',
+            'requests',
         ],
 
         extras_require={

--- a/tests/runonce.sh
+++ b/tests/runonce.sh
@@ -28,3 +28,11 @@ zget -t 3 LICENSE /dev/null
 
 zput -vv -q -t 3 "tests/filename with spaces" &
 zget -vv -q -t 3 "filename with spaces" /dev/null
+
+# In normal use tokens would be automatically generated, but specifying them
+# manually exercises the same code.
+zput "tests/filename with spaces" T0KN &
+cd `mktemp -d`
+zget T0KN
+ls
+test -f "filename with spaces"

--- a/zget/get.py
+++ b/zget/get.py
@@ -166,8 +166,10 @@ def get(
             "Downloading from %s:%d" % (address, port)
         )
         if mechanism == 'token':
+            utils.logger.debug('Requesting using token')
             path = secret_token
         else:  # mechanism == 'filehash'
+            utils.logger.debug('Requesting using filename')
             path = token_or_filename
         url = "http://" + address + ":" + str(port) + "/" + path
 

--- a/zget/get.py
+++ b/zget/get.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
-import os
 import sys
 import socket
-try:
-    import urllib.request as urllib
-except ImportError:
-    import urllib
 import hashlib
 import argparse
 

--- a/zget/get.py
+++ b/zget/get.py
@@ -119,8 +119,10 @@ def get(
 
     Parameters
     ----------
-    filename : string
-        The filename to be transferred
+    token_or_filename : string
+        The token from zput, or the filename to be transferred. If not given,
+        a random token will be generated and printed to use with zput.
+        Optional.
     output : string
         The filename to save to. Optional.
     reporthook : callable

--- a/zget/get.py
+++ b/zget/get.py
@@ -135,8 +135,8 @@ def get(
 
     """
     broadcast_token, secret_token = utils.prepare_token(token_or_filename)
-    utils.logger.debug('Broadcast token:', broadcast_token)
-    utils.logger.debug('Secret token:', secret_token)
+    utils.logger.debug('Broadcast token: %s', broadcast_token)
+    utils.logger.debug('Secret token: %s', secret_token)
 
     zeroconf = Zeroconf()
     if token_or_filename is not None:

--- a/zget/get.py
+++ b/zget/get.py
@@ -127,8 +127,6 @@ def get(
     """
     basename = os.path.basename(filename)
     filehash = hashlib.sha1(basename.encode('utf-8')).hexdigest()
-    if output is None:
-        output = filename
 
     zeroconf = Zeroconf()
     listener = ServiceListener()
@@ -155,7 +153,7 @@ def get(
         url = "http://" + listener.address + ":" + str(listener.port) + "/" + \
               urllib.pathname2url(filename)
 
-        urllib.urlretrieve(
+        utils.urlretrieve(
             url, output,
             reporthook=reporthook
         )

--- a/zget/get.py
+++ b/zget/get.py
@@ -100,7 +100,7 @@ def cli(inargs=None):
     except Exception as e:
         if args.verbose:
             raise
-        utils.logger.error(e.message)
+        utils.logger.error("%s", e)
         sys.exit(1)
 
 

--- a/zget/get.py
+++ b/zget/get.py
@@ -82,7 +82,8 @@ def cli(inargs=None):
     )
     parser.add_argument(
         'token', nargs='?',
-        help="The token to look for on the network, if zput was already started"
+        help=("The token to look for on the network, if zput was already"
+              "started")
     )
     parser.add_argument(
         'output',
@@ -147,14 +148,15 @@ def get(
         filehash = None
     listener = ServiceListener(broadcast_token, filehash)
 
-    utils.logger.debug("Looking for " + broadcast_token + "._zget._http._tcp.local.")
+    utils.logger.debug("Looking for " + broadcast_token +
+                       "._zget._http._tcp.local.")
 
     browser = ServiceBrowser(zeroconf, "_zget._http._tcp.local.", listener)
 
     if token_or_filename is None:
         print('Ready to receive a file.')
         print("Ask your friend to 'zput <filename> %s%s'"
-                % (broadcast_token, secret_token))
+              % (broadcast_token, secret_token))
 
     try:
         try:

--- a/zget/put.py
+++ b/zget/put.py
@@ -7,6 +7,10 @@ import os
 import sys
 import socket
 import argparse
+try:
+    from urllib.parse import unquote  # Py3
+except ImportError:
+    from urllib import unquote  # Py2
 
 from zeroconf import ServiceInfo, Zeroconf
 try:
@@ -50,8 +54,8 @@ class FileHandler(BaseHTTPRequestHandler):
     """
 
     def do_GET(self):
-        if self.path in ('/' + self.server.token,
-                         '/' + self.server.basename):
+        if unquote(self.path) in ('/' + self.server.token,
+                                  '/' + self.server.basename):
             utils.logger.info("Peer found. Uploading...")
             full_path = os.path.join(os.curdir, self.server.filename)
             with open(full_path, 'rb') as fh:

--- a/zget/put.py
+++ b/zget/put.py
@@ -187,6 +187,9 @@ def put(
     ----------
     filename : string
         The filename to be transferred
+    token : string
+        The token from zget to co-ordinate the transfer. If not given, a token
+        will be generated and printed to use with zget. Optional.
     interface : string
         The network interface to use. Optional.
     address : string

--- a/zget/put.py
+++ b/zget/put.py
@@ -223,8 +223,8 @@ def put(
     filehash = hashlib.sha1(basename.encode('utf-8')).hexdigest()
 
     broadcast_token, secret_token = utils.prepare_token(token)
-    utils.logger.debug('Broadcast token:', broadcast_token)
-    utils.logger.debug('Secret token:', secret_token)
+    utils.logger.debug('Broadcast token: %s', broadcast_token)
+    utils.logger.debug('Secret token: %s', secret_token)
 
     if interface is None:
         interface = utils.default_interface()

--- a/zget/put.py
+++ b/zget/put.py
@@ -245,6 +245,8 @@ def put(
     server = StateHTTPServer((address, port), FileHandler)
     server.timeout = timeout
     server.token = secret_token
+    # We respond to the full token so recipients with older versions of zget
+    # can listen for the hash of the token.
     server.complete_token = broadcast_token + secret_token
     server.filename = filename
     server.basename = basename

--- a/zget/put.py
+++ b/zget/put.py
@@ -63,6 +63,12 @@ class FileHandler(BaseHTTPRequestHandler):
                 maxsize = os.path.getsize(full_path)
                 self.send_response(200)
                 self.send_header('Content-type', 'application/octet-stream')
+                self.send_header(
+                    'Content-disposition',
+                    'inline; filename="%s"' % os.path.basename(
+                        self.server.filename
+                    )
+                )
                 self.send_header('Content-length', maxsize)
                 self.end_headers()
 

--- a/zget/put.py
+++ b/zget/put.py
@@ -79,6 +79,7 @@ class FileHandler(BaseHTTPRequestHandler):
             self.server.downloaded = True
 
         else:
+            utils.logger.info('Request path: %r', self.path)
             self.send_response(404)
             self.end_headers()
             raise RuntimeError("Invalid request received. Aborting.")
@@ -168,7 +169,7 @@ def cli(inargs=None):
     except Exception as e:
         if args.verbose:
             raise
-        utils.logger.error(e.message)
+        utils.logger.error("%s", e)
         sys.exit(1)
 
 

--- a/zget/put.py
+++ b/zget/put.py
@@ -255,7 +255,7 @@ def put(
     if token is None:
         print(filename, 'is now available on the network')
         print("Ask your friend to 'zget %s%s'"
-                % (broadcast_token, secret_token))
+              % (broadcast_token, secret_token))
 
     zeroconf = Zeroconf()
     try:

--- a/zget/utils.py
+++ b/zget/utils.py
@@ -181,6 +181,7 @@ def urlretrieve(
     reporthook=None
 ):
     r = requests.get(url, stream=True)
+    r.raise_for_status()
     try:
         maxsize = int(r.headers['content-length'])
     except KeyError:

--- a/zget/utils.py
+++ b/zget/utils.py
@@ -4,6 +4,7 @@ import os
 import netifaces
 import logging
 import progressbar
+import random
 import re
 import requests
 try:
@@ -152,6 +153,7 @@ def ip_addr(interface):
     except KeyError:
         raise ValueError("You have selected an invalid interface")
 
+
 def unique_filename(filename, limit=maxsize):
     if not os.path.exists(filename):
         return filename
@@ -204,3 +206,19 @@ def urlretrieve(
                 f.write(chunk)
                 if reporthook is not None:
                     reporthook(i, 1024 * 8, maxsize)
+
+
+def prepare_token(given_token, length=4):
+    if given_token is None:
+        # Generate a new random token
+        # This is the same alphabet used in Douglas Crockford's base32 variant
+        alphabet = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+        token = ''.join(random.choice(alphabet) for _ in range(length))
+    else:
+        # Normalise the token
+        token = given_token.upper().replace('I', '1').replace('L', '1')\
+                .replace('O', '0')
+
+    # Split it into the broadcast part and the secret part
+    _split_ix = len(token)//2
+    return token[:_split_ix], token[_split_ix:]

--- a/zget/utils.py
+++ b/zget/utils.py
@@ -218,9 +218,10 @@ def prepare_token(given_token, length=4):
         alphabet = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
         token = ''.join(random.choice(alphabet) for _ in range(length))
     else:
-        # Normalise the token
-        token = given_token.upper().replace('I', '1').replace('L', '1')\
-                .replace('O', '0')
+        # I think similar looking characters (Il1, O0) in the token should be
+        # normalised here; the alphabet is chosen to allow that. But Nils
+        # doesn't like this. -TK
+        token = given_token
 
     # Split it into the broadcast part and the secret part
     _split_ix = len(token)//2

--- a/zget/utils.py
+++ b/zget/utils.py
@@ -189,8 +189,10 @@ def urlretrieve(
 
     if output is None:
         try:
+            logger.debug("Content-Disposition header: %r",
+                         r.headers['content-disposition'])
             filename = re.findall(
-                "filename=(\S+)", r.headers['content-disposition']
+                r'filename="(.+?)"', r.headers['content-disposition']
             )[0].strip('\'"')
         except (IndexError, KeyError):
             filename = urlparse.unquote(


### PR DESCRIPTION
Following our discussions on #5, here's my version of using random tokens as identifiers. I haven't changed any of the docstrings or tests yet, I just wanted to have a play with it and see how complex it is first.

Technically, the user can choose the token manually if they want, as in your proposal, but the intended use it to start the first side without a token. In that case, it will generate a new random filename and print a helpful message.

E.g. with the sender initiating:

```
$ zput requirements.txt 
requirements.txt is now available on the network
Ask your friend to 'zget 3KSF'
requirements.txt 100% |###################################| Time: 0.25 512.7 B/s

# Recipient
$ zget 3ksf
requirements_1.txt 100% |###############################| Time: 0.00  41.7 KiB/s
```

Or with the recipient initiating:

```
$ zget
Ready to receive a file.
Ask your friend to 'zput <filename> QJX8'
setup_1.py 100% |#######################################| Time: 0.00   1.0 MiB/s

# Sender
$ zput setup.py qjx8
setup.py 100% |#########################################| Time: 0.25   7.0 KiB/s
```

The tokens don't use I, L or O. If you type in I or L, it will convert them to 1; if you type O, it will convert to 0 (zero). U is also unused to avoid generating some unpleasant four letter words. This alphabet is from Douglas Crockford's base32 variant. Z/2 may still be ambiguous - we could tweak this, e.g. take Z out and leave L in.